### PR TITLE
Reviewed Method Access Control.

### DIFF
--- a/lib/pio/icmp/frame.rb
+++ b/lib/pio/icmp/frame.rb
@@ -48,14 +48,24 @@ module Pio
         ~((icmp_csum & 0xffff) + (icmp_csum >> 16)) & 0xffff
       end
 
+      def ip_sum
+        ~((ip_csum & 0xffff) + (ip_csum >> 16)) & 0xffff
+      end
+
+      def to_binary
+        if num_bytes < MINIMUM_FRAME_LENGTH
+          to_binary_s + "\000" * (MINIMUM_FRAME_LENGTH - num_bytes)
+        else
+          to_binary_s
+        end
+      end
+
+      private
+
       def icmp_csum
         icmp_2bytewise_slices.reduce(0) do |acc, each|
           acc + each
         end
-      end
-
-      def ip_sum
-        ~((ip_csum & 0xffff) + (ip_csum >> 16)) & 0xffff
       end
 
       def ip_csum
@@ -111,14 +121,6 @@ module Pio
 
       def ipttl_ipproto
         ip_ttl << 8 | ip_protocol
-      end
-
-      def to_binary
-        if num_bytes < MINIMUM_FRAME_LENGTH
-          to_binary_s + "\000" * (MINIMUM_FRAME_LENGTH - num_bytes)
-        else
-          to_binary_s
-        end
       end
     end
   end

--- a/lib/pio/icmp/message.rb
+++ b/lib/pio/icmp/message.rb
@@ -10,12 +10,6 @@ module Pio
       extend Forwardable
       include MessageUtil
 
-      def self.create_from(frame)
-        message = allocate
-        message.instance_variable_set :@frame, frame
-        message
-      end
-
       def initialize(options)
         @options = options
         @frame = Icmp::Frame.new(option_hash)
@@ -45,6 +39,12 @@ module Pio
       def_delegators :@frame, :to_binary
 
       private
+
+      def self.create_from(frame)
+        message = allocate
+        message.instance_variable_set :@frame, frame
+        message
+      end
 
       # rubocop:disable MethodLength
       def default_options

--- a/lib/pio/message_util.rb
+++ b/lib/pio/message_util.rb
@@ -2,6 +2,9 @@
 module Pio
   # Pio Message Util.
   module MessageUtil
+
+    private
+
     def option_hash
       mandatory_options.reduce({}) do | opt, each |
         klass = option_to_klass[each]


### PR DESCRIPTION
※この意図としては、`rake yard:list_undoc`から
内部でしか使っていないメソッドを除外させるためです。

一旦、ICMPクラスについて、
下記のメソッドをprivateに入れました。
- Icmp::Frame
  下記以外のメソッド
  - ip_sum  
  - ip_packet_length  
  - icmp_sum  
  - echo_data_length  
  - message_type  
  - to_binary  
- Icmp::Message
  - create_from
- Pio::MessageUtil
  - option_hash

問題などございましたら、ご指摘お願い致します。
宜しくお願いします。
