### PR TITLE
Refactor SendOutPort class

### DIFF
--- a/features/open_flow10/send_out_port.feature
+++ b/features/open_flow10/send_out_port.feature
@@ -8,11 +8,11 @@ Feature: Pio::SendOutPort
       """
     Then it should finish successfully
     And the action has the following fields and values:
-      | field       | value |
-      | action_type |     0 |
-      | length      |     8 |
-      | port        |     1 |
-      | max_length  | 65535 |
+      | field         | value |
+      | action_type   |     0 |
+      | action_length |     8 |
+      | port          |     1 |
+      | max_length    | 65535 |
 
   Scenario: new(:all)
     When I try to create an OpenFlow action with:
@@ -21,11 +21,11 @@ Feature: Pio::SendOutPort
       """
     Then it should finish successfully
     And the action has the following fields and values:
-      | field       | value |
-      | action_type |     0 |
-      | length      |     8 |
-      | port        |  :all |
-      | max_length  | 65535 |
+      | field         | value |
+      | action_type   |     0 |
+      | action_length |     8 |
+      | port          |  :all |
+      | max_length    | 65535 |
 
   Scenario: new(:controller)
     When I try to create an OpenFlow action with:
@@ -34,11 +34,11 @@ Feature: Pio::SendOutPort
       """
     Then it should finish successfully
     And the action has the following fields and values:
-      | field       |       value |
-      | action_type |           0 |
-      | length      |           8 |
-      | port        | :controller |
-      | max_length  |       65535 |
+      | field         |       value |
+      | action_type   |           0 |
+      | action_length |           8 |
+      | port          | :controller |
+      | max_length    |       65535 |
 
   Scenario: new(:local)
     When I try to create an OpenFlow action with:
@@ -47,11 +47,11 @@ Feature: Pio::SendOutPort
       """
     Then it should finish successfully
     And the action has the following fields and values:
-      | field       |  value |
-      | action_type |      0 |
-      | length      |      8 |
-      | port        | :local |
-      | max_length  |  65535 |
+      | field         |  value |
+      | action_type   |      0 |
+      | action_length |      8 |
+      | port          | :local |
+      | max_length    |  65535 |
 
   Scenario: new(:table)
     When I try to create an OpenFlow action with:
@@ -60,11 +60,11 @@ Feature: Pio::SendOutPort
       """
     Then it should finish successfully
     And the action has the following fields and values:
-      | field       |  value |
-      | action_type |      0 |
-      | length      |      8 |
-      | port        | :table |
-      | max_length  |  65535 |
+      | field         |  value |
+      | action_type   |      0 |
+      | action_length |      8 |
+      | port          | :table |
+      | max_length    |  65535 |
 
   Scenario: new(:in_port)
     When I try to create an OpenFlow action with:
@@ -73,11 +73,11 @@ Feature: Pio::SendOutPort
       """
     Then it should finish successfully
     And the action has the following fields and values:
-      | field       |    value |
-      | action_type |        0 |
-      | length      |        8 |
-      | port        | :in_port |
-      | max_length  |    65535 |
+      | field         |    value |
+      | action_type   |        0 |
+      | action_length |        8 |
+      | port          | :in_port |
+      | max_length    |    65535 |
 
   Scenario: new(:normal)
     When I try to create an OpenFlow action with:
@@ -86,11 +86,11 @@ Feature: Pio::SendOutPort
       """
     Then it should finish successfully
     And the action has the following fields and values:
-      | field       |   value |
-      | action_type |       0 |
-      | length      |       8 |
-      | port        | :normal |
-      | max_length  |   65535 |
+      | field         |   value |
+      | action_type   |       0 |
+      | action_length |       8 |
+      | port          | :normal |
+      | max_length    |   65535 |
 
   Scenario: new(:flood)
     When I try to create an OpenFlow action with:
@@ -99,8 +99,8 @@ Feature: Pio::SendOutPort
       """
     Then it should finish successfully
     And the action has the following fields and values:
-      | field       |  value |
-      | action_type |      0 |
-      | length      |      8 |
-      | port        | :flood |
-      | max_length  |  65535 |
+      | field         |  value |
+      | action_type   |      0 |
+      | action_length |      8 |
+      | port          | :flood |
+      | max_length    |  65535 |

--- a/lib/pio/open_flow/action.rb
+++ b/lib/pio/open_flow/action.rb
@@ -1,0 +1,46 @@
+require 'bindata'
+
+module Pio
+  module OpenFlow
+    # OpenFlow actions.
+    class Action
+      def self.inherited(child_klass)
+        child_klass.const_set :Format, Class.new(BinData::Record)
+      end
+
+      def self.action_header(options)
+        module_eval do
+          endian :big
+
+          uint16 :action_type, value: options.fetch(:action_type)
+          uint16 :action_length, value: options.fetch(:action_length)
+        end
+      end
+
+      def self.read(raw_data)
+        action = allocate
+        action.instance_variable_set :@format, const_get(:Format).read(raw_data)
+        action
+      end
+
+      def self.method_missing(method, *args, &block)
+        const_get(:Format).__send__ method, *args, &block
+        return if method == :endian || method == :virtual
+        define_method(args.first) { @format.__send__ args.first }
+      end
+
+      def initialize(user_options)
+        @format = self.class.const_get(:Format).new(user_options)
+      end
+
+      # FIXME: delete this method
+      def length
+        @format.action_length
+      end
+
+      def to_binary
+        @format.to_binary_s
+      end
+    end
+  end
+end

--- a/lib/pio/open_flow10/send_out_port.rb
+++ b/lib/pio/open_flow10/send_out_port.rb
@@ -1,35 +1,15 @@
-require 'bindata'
-require 'forwardable'
 require 'pio/monkey_patch/integer'
+require 'pio/open_flow/action'
 require 'pio/open_flow10/port16'
 
 module Pio
   module OpenFlow10
     # An action to output a packet to a port.
-    class SendOutPort
-      # OpenFlow 1.0 OFPAT_OUTPUT action format.
-      class Format < BinData::Record
-        endian :big
-
-        uint16 :action_type, value: 0
-        uint16 :action_length, value: 8
-        port16 :port
-        uint16 :max_length, initial_value: 2**16 - 1
-      end
-
-      def self.read(raw_data)
-        send_out_port = allocate
-        send_out_port.instance_variable_set :@format, Format.read(raw_data)
-        send_out_port
-      end
-
-      extend Forwardable
-
-      def_delegators :@format, :action_type
-      def_delegator :@format, :action_length, :length
-      def_delegators :@format, :port
-      def_delegators :@format, :max_length
-      def_delegator :@format, :to_binary_s, :to_binary
+    class SendOutPort < OpenFlow::Action
+      action_header action_type: 0,
+                    action_length: 8
+      port16 :port
+      uint16 :max_length, initial_value: 2**16 - 1
 
       # rubocop:disable MethodLength
       def initialize(user_options)
@@ -45,7 +25,7 @@ module Pio
           fail(ArgumentError,
                'The max_length should be an unsigned 16bit integer.')
         end
-        @format = Format.new(options)
+        super(options)
       end
       # rubocop:enable MethodLength
 


### PR DESCRIPTION
Delete SendOutPort::Format class using Pio::OpenFlow::Action.
Refs #253