### PR TITLE
Refactor SendOutPort class

### DIFF
--- a/lib/pio/open_flow13/send_out_port.rb
+++ b/lib/pio/open_flow13/send_out_port.rb
@@ -1,44 +1,25 @@
-require 'forwardable'
+require 'pio/open_flow/action'
 require 'pio/open_flow13/port32'
 
 # Base module.
 module Pio
   module OpenFlow13
     # Output to switch port.
-    class SendOutPort
-      # OpenFlow 1.3.4 OFPAT_OUTPUT action format.
-      class Format < BinData::Record
-        NO_BUFFER = 0xffff
+    class SendOutPort < OpenFlow::Action
+      NO_BUFFER = 0xffff
 
-        endian :big
-
-        uint16 :action_type, value: 0
-        uint16 :action_length, value: 16
-        port32 :port
-        uint16 :max_length, initial_value: NO_BUFFER
-        uint48 :padding
-      end
-
-      def self.read(raw_data)
-        allocate.tap do |send_out_port|
-          send_out_port.instance_variable_set :@format, Format.read(raw_data)
-        end
-      end
-
-      extend Forwardable
-
-      def_delegators :@format, :action_type
-      def_delegator :@format, :action_length, :length
-      def_delegators :@format, :port
-      def_delegator :@format, :to_binary_s, :to_binary
+      action_header action_type: 0, action_length: 16
+      port32 :port
+      uint16 :max_length, initial_value: NO_BUFFER
+      uint48 :padding
 
       def initialize(port)
-        @format = Format.new(port: port)
+        super(port: port)
       end
 
       def max_length
         case @format.max_length
-        when Format::NO_BUFFER
+        when NO_BUFFER
           :no_buffer
         else
           @format.max_length


### PR DESCRIPTION
Delete SendOutPort::Format class using Pio::OpenFlow::Action
Refs #253.